### PR TITLE
Added Iuclid Form Helpers for recursive construction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+
+calypso/
+.tmp/
+node_modules/

--- a/app/js/constant/templates.ts
+++ b/app/js/constant/templates.ts
@@ -18,8 +18,12 @@ module calypso.Const.Templates {
     export const BREADCRUMB_TPL = BASE + 'directives/breadcrumbs.html';
     export const PAGING_TPL = BASE + 'directives/paging.html';
 
+    export const IUCLID_FORM_PICKER_TPL = BASE + 'directives/iuclid-form/iuclid-form-picker.html';
+    export const IUCLID_FORM_TPL = BASE + 'directives/iuclid-form/iuclid-form.html';
+    export const IUCLID_FORM_CONTENTS_TPL = BASE + 'directives/iuclid-form/iuclid-form-contents.html';
+    export const IUCLID_ATTRIBUTE_BLOCK_TPL = BASE + 'directives/iuclid-attributes/iuclid-block.html';
     export const IUCLID_ATTRIBUTE_BOOLEAN_TPL = BASE + 'directives/iuclid-attributes/iuclid-attribute-boolean.html';
-    export const IUCLID_ATTRIBUTE_TEXT_TPL = BASE + 'directives/iuclid-attributes/iuclid-attribute-text.html';
+    export const IUCLID_ATTRIBUTE_TEXT_TPL = BASE + 'directives/iuclid-attributes/iuclid-text.html';
     export const IUCLID_ATTRIBUTE_DATE_TPL = BASE + 'directives/iuclid-attributes/iuclid-attribute-date.html';
     export const IUCLID_ATTRIBUTE_PICK_LIST_TPL = BASE + 'directives/iuclid-attributes/iuclid-pick-list.html';
 

--- a/app/js/directive/iuclid-attributes/iuclidBlock.ts
+++ b/app/js/directive/iuclid-attributes/iuclidBlock.ts
@@ -4,13 +4,13 @@ module calypso.Directives {
         content: any
     }
 
-    angular.module('calypso.directives').directive('iuclidText', [
+    angular.module('calypso.directives').directive('iuclidBlock', [
         function() {
             return {
                 scope: {
                     content: '='
                 },
-                templateUrl: calypso.Const.Templates.IUCLID_ATTRIBUTE_TEXT_TPL
+                templateUrl: calypso.Const.Templates.IUCLID_ATTRIBUTE_BLOCK_TPL
             }
         }
     ]);

--- a/app/js/directive/iuclid-form/iuclidForm.ts
+++ b/app/js/directive/iuclid-form/iuclidForm.ts
@@ -1,0 +1,18 @@
+module calypso.Directives {
+
+    interface Scope extends ng.IScope {
+        document: any
+        loadDoc: () => void
+    }
+
+    angular.module('calypso.directives').directive('iuclidForm', [
+        function() {
+            return {
+                scope: {
+                    document: '='
+                },
+                templateUrl: calypso.Const.Templates.IUCLID_FORM_TPL
+            }
+        }
+    ]);
+}

--- a/app/js/directive/iuclid-form/iuclidFormContent.ts
+++ b/app/js/directive/iuclid-form/iuclidFormContent.ts
@@ -1,0 +1,17 @@
+module calypso.Directives {
+
+    interface Scope extends ng.IScope {
+        contents: any
+    }
+
+    angular.module('calypso.directives').directive('iuclidFormContent', [
+        function() {
+            return {
+                scope: {
+                    contents: '='
+                },
+                templateUrl: calypso.Const.Templates.IUCLID_FORM_CONTENTS_TPL
+            }
+        }
+    ]);
+}

--- a/app/js/directive/iuclid-form/iuclidFormPicker.ts
+++ b/app/js/directive/iuclid-form/iuclidFormPicker.ts
@@ -1,0 +1,95 @@
+module calypso.Directives {
+
+    interface Scope extends ng.IScope {
+        document: any
+        loadDoc: () => void
+    }
+
+    angular.module('calypso.directives').directive('iuclidFormPicker', [
+        function() {
+            return {
+                scope: {},
+                templateUrl: calypso.Const.Templates.IUCLID_FORM_PICKER_TPL,
+                link: (scope: Scope) => {
+
+                    /**
+                     * loadDoc is a function which is setting a document
+                     * definition on the scope.document attribute
+                     * This is used to pass to the <iuclid-form> directive
+                     */
+                    scope.loadDoc = function() {
+                        scope.document = {
+                            "identifier": "LEGAL_ENTITY",
+                            "version": "2.0",
+                            "provider": "domain",
+                            "@lang": "en",
+                            "contents": [{
+                                "type": "block",
+                                "name": "GeneralInfo",
+                                "title": "General information",
+                                "contents": [{
+                                    "type": "text",
+                                    "name": "LegalEntityName",
+                                    "title": "Legal entity name",
+                                    "required": true,
+                                    "mimeType": "text/plain",
+                                    "maxLength": 255
+                                }, {
+                                    "type": "picklist",
+                                    "name": "LegalEntityType",
+                                    "title": "Legal entity type",
+                                    "phrasegroup": "N01"
+                                }, {
+                                    "type": "text",
+                                    "name": "Remarks",
+                                    "title": "Remarks",
+                                    "mimeType": "text/plain",
+                                    "maxLength": 32768
+                                }, {
+                                    "type": "block",
+                                    "name": "OtherNames",
+                                    "title": "Other names",
+                                    "protectedBy": "LEGAL_ENTITY.GeneralInfo.OtherNames.DataProtection",
+                                    "multiple": true,
+                                    "contents": [{
+                                        "type": "dataProtection",
+                                        "name": "DataProtection",
+                                        "title": "Flags"
+                                    }, {
+                                        "type": "text",
+                                        "name": "Name",
+                                        "title": "Name",
+                                        "mimeType": "text/plain",
+                                        "maxLength": 255
+                                    }, {
+                                        "type": "date",
+                                        "name": "DateAttribute",
+                                        "title": "Date Attribute",
+                                        "withTime": false
+                                    }, {
+                                        "type": "block",
+                                        "name": "ThreeLevelsDeep",
+                                        "title": "We are now 3 Levels Deep!",
+                                        "contents": [{
+                                            "type": "numeric",
+                                            "name": "NumericAttribute",
+                                            "title": "Numeric Attribute",
+                                            "numericType": "INTEGER",
+                                            "min": 10,
+                                            "max": 99
+                                        }, {
+                                            "type": "quantity",
+                                            "name": "QuantityAttribute",
+                                            "title": "Phrase Group Quantity Attribute",
+                                            "unitPhraseGroup": "NL_01"
+                                        }]
+                                    }]
+                                }]
+                            }]
+                        };
+                    }
+                }
+            }
+        }
+    ]);
+}

--- a/app/js/directive/searchBar.ts
+++ b/app/js/directive/searchBar.ts
@@ -16,7 +16,7 @@ module calypso.Directives {
                 templateUrl: Templates.SEARCH_BAR_TPL,
                 link: (scope: Scope, element: ng.IAugmentedJQuery) => {
                     //run an initial blank search
-                    EventBus.publish(calypso.Const.Events.applyFilters);
+                    // EventBus.publish(calypso.Const.Events.applyFilters);
 
                     let mainSearchInput = element.find('input');
 

--- a/app/scss/components/_all.scss
+++ b/app/scss/components/_all.scss
@@ -5,3 +5,5 @@
 @import "product-list";
 @import "breadcrumbs";
 @import "paging";
+
+@import "form/all";

--- a/app/scss/components/_main.scss
+++ b/app/scss/components/_main.scss
@@ -1,3 +1,6 @@
+html {
+    font-size: 80%;
+}
 body {
     height: 100%;
     font-family: Helvetica;

--- a/app/scss/components/form/_all.scss
+++ b/app/scss/components/form/_all.scss
@@ -1,0 +1,3 @@
+@import "form";
+@import "block";
+@import "text";

--- a/app/scss/components/form/_block.scss
+++ b/app/scss/components/form/_block.scss
@@ -1,0 +1,9 @@
+.form__content--block {
+  border: 1px solid #e8e8e8;
+  padding: 20px;
+  margin: 10px;
+
+  h3 {
+    padding-left: 10px;
+  }
+}

--- a/app/scss/components/form/_form.scss
+++ b/app/scss/components/form/_form.scss
@@ -1,0 +1,31 @@
+.form {
+  margin: 25px;
+  padding: 35px;
+  background-color: #FFF;
+  border: 1px solid #dadada;
+  border-radius: 5px;
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
+}
+
+.form__content {
+  padding: 10px;
+
+  label {
+    color: #31373d;
+    display: block;
+    margin-bottom: 5px;
+    font-size: 1.5rem;
+    line-height: 2rem;
+    font-weight: 400;
+    text-transform: initial;
+    letter-spacing: initial;
+  }
+
+  .no-type-warn {
+    font-weight: 400;
+    font-size: 1.5rem;
+    color: #b3454e;
+    border: 1px solid;
+    padding: 10px;
+  }
+}

--- a/app/scss/components/form/_text.scss
+++ b/app/scss/components/form/_text.scss
@@ -1,0 +1,20 @@
+.form__content--text {
+  textarea {
+    min-height: 100px;
+  }
+  input,textarea {
+    display: inline-block;
+    width: 100%;
+    max-width: 100%;
+    min-width: 75px;
+    height: auto;
+    vertical-align: baseline;
+    margin: 0;
+    padding: 5px 10px;
+    color: #000000;
+    border: 1px solid #d3dbe2;
+    font-size: 1.6rem;
+    line-height: 2.4rem;
+    font-weight: 400;
+  }
+}

--- a/app/templates/directives/iuclid-attributes/iuclid-block.html
+++ b/app/templates/directives/iuclid-attributes/iuclid-block.html
@@ -1,0 +1,4 @@
+<div class="form__content form__content--block">
+    <h3>{{ content.title }}</h3>
+    <iuclid-form-content contents="content.contents"></iuclid-form-content>
+</div>

--- a/app/templates/directives/iuclid-attributes/iuclid-text.html
+++ b/app/templates/directives/iuclid-attributes/iuclid-text.html
@@ -1,3 +1,23 @@
-div>
-    <span class="label">{{ iuclidtext.label }}</span>
+<div class="form__content form__content--text">
+    <label>{{ content.title }}</label>
+    <!--
+        If the content's max length is greater than 256
+        then we should use a text input to provide the
+        ability to provide a larger body of text.
+        Maybe in the future we want to provide some rich
+        text editor?
+    -->
+    <textarea ng-if="content.maxLength && content.maxLength > 256"
+              ng-model="content.value"
+              maxlength="{{ content.maxLength }}">
+    </textarea>
+    <!--
+        Otherwise for type text where the max length is less
+        then 256 we should use a regular text input since
+        it's more likely this is a relatively shorter value
+    -->
+    <input ng-if="!content.maxLength || content.maxLength <= 256"
+           type="text"
+           maxlength="{{ content.maxLength }}"
+           ng-model="content.value" />
 </div>

--- a/app/templates/directives/iuclid-form/iuclid-form-contents.html
+++ b/app/templates/directives/iuclid-form/iuclid-form-contents.html
@@ -1,0 +1,16 @@
+<div ng-repeat="content in contents" ng-switch="content.type">
+    <iuclid-block ng-switch-when="block" content="content"></iuclid-block>
+    <iuclid-text ng-switch-when="text" content="content"></iuclid-text>
+    <!--
+        I think for all our form attributes we should just pass it the whole content object
+        Check my <iuclid-block> and <iuclid-text> implementations for how to pass the whole object
+     -->
+    <iuclid-pick-list ng-switch-when="picklist" code="{{ content.phrasegroup }}" content="content"></iuclid-pick-list>
+    <!--
+        The template for adding new form types is like this:
+        <iuclid-$type ng-switch-when="$type" content="content" ></iculid-$type>
+    -->
+    <div ng-switch-default class="form__content">
+        <pre class="no-type-warn">No Form Attribute Implementation for Type:[{{ content.type }}]<br><b>Content:</b> {{ content }}</pre>
+    </div>
+</div>

--- a/app/templates/directives/iuclid-form/iuclid-form-picker.html
+++ b/app/templates/directives/iuclid-form/iuclid-form-picker.html
@@ -1,0 +1,20 @@
+<!--
+    If there is no document object defined then we
+    should give the user the ability to choose one
+    For now this is just a button to load a mock object
+    which matches the structure of a Document Definition
+
+    we check this with the `ng-if`
+-->
+<div ng-if="!document" style="padding: 50px;">
+    <p>Click the button below to load a Document (maybe in the future this is a drop down to load different forms)</p>
+    <button ng-click="loadDoc()" class="btn btn-primary">Load Document</button>
+</div>
+<!--
+    If there is a document defined then we'll created
+    an instance of our <iuclid-form> and pass the document
+    object to it to be rendered
+-->
+<div ng-if="document">
+    <iuclid-form document="document"></iuclid-form>
+</div>

--- a/app/templates/directives/iuclid-form/iuclid-form.html
+++ b/app/templates/directives/iuclid-form/iuclid-form.html
@@ -1,0 +1,4 @@
+<div class="form">
+    <h2>{{ document.identifier }} <small>{{ document.provider }} {{ document.version }}</small></h2>
+    <iuclid-form-content contents="document.contents"></iuclid-form-content>
+</div>

--- a/app/templates/directives/search-bar.html
+++ b/app/templates/directives/search-bar.html
@@ -1,6 +1,5 @@
 <div class="search-bar">
     <div class="main-search">
-        <div class="coveo-logoo"></div>
         <div class="nav-buttons">
             <a href="/#/">
                 <i class="fa fa-home"></i>

--- a/app/templates/new-substance.html
+++ b/app/templates/new-substance.html
@@ -1,2 +1,2 @@
 <h1>new substance</h1>
-<generic-form form-elements="elements"></generic-form>
+<iuclid-form-picker></iuclid-form-picker>


### PR DESCRIPTION
This sets up the ability to recursively draw a form from a
document definition object. We can plug in the different
form attribute components into the iuclid-form-contents.html
template and add an ng-switch-when for that attribute type